### PR TITLE
Fix deprecation warning 2025.9

### DIFF
--- a/custom_components/cover_rf_time_based/cover.py
+++ b/custom_components/cover_rf_time_based/cover.py
@@ -117,7 +117,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     }
 )
 
-POSITION_SCHEMA = vol.Schema(
+POSITION_SCHEMA = cv.make_entity_service_schema(
     {
         vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
         vol.Required(ATTR_POSITION): cv.positive_int,
@@ -127,7 +127,7 @@ POSITION_SCHEMA = vol.Schema(
 )
 
 
-ACTION_SCHEMA = vol.Schema(
+ACTION_SCHEMA = cv.make_entity_service_schema(
     {
         vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
         vol.Required(ATTR_ACTION): cv.string

--- a/custom_components/cover_rf_time_based/manifest.json
+++ b/custom_components/cover_rf_time_based/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "cover_rf_time_based",
   "name": "Cover Time Based (script/entity)",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "documentation": "https://github.com/nagyrobi/home-assistant-custom-components-cover-rf-time-based",
   "iot_class": "assumed_state",
   "codeowners": ["@davidramosweb", "@nagyrobi", "@Alfiegerner"]


### PR DESCRIPTION
🛠️ Fix deprecation warnings for Home Assistant 2025.9
This PR fixes two deprecation warnings introduced in Home Assistant and scheduled to become breaking in version 2025.9.

❗ Deprecation details:
Warnings were raised due to usage of platform.async_register_entity_service with a non-entity service schema at:

custom_components/cover_rf_time_based/cover.py, line 184

custom_components/cover_rf_time_based/cover.py, line 188

✅ Changes made:
Updated the async_register_entity_service calls to use vol.Schema that matches the expected entity service schema format.